### PR TITLE
VT-5543 Support both old ("yyyyMMdd-HH") and new ("yyyyMMddHH") date format for hourly buffer files 

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -37,7 +37,7 @@ function Invoke-Build()
     Write-Output "Creating packages"
     foreach ($project in $projects)
     {
-        & dotnet pack $project -c Release -o ..\..\artifacts  -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg /p:PackageVersion=8.50.3    
+        & dotnet pack $project -c Release -o ..\..\artifacts  -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg /p:PackageVersion=8.51.1    
     }
   
     if($LASTEXITCODE -ne 0) 

--- a/src/Serilog.Formatting.Elasticsearch/Serilog.Formatting.Elasticsearch.csproj
+++ b/src/Serilog.Formatting.Elasticsearch/Serilog.Formatting.Elasticsearch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     
   <PropertyGroup>
-    <VersionPrefix>8.50.3</VersionPrefix>
+    <VersionPrefix>8.51.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Michiel van Oudheusden, Martijn Laarman, Mogens Heller Grabe, Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>

--- a/src/Serilog.Sinks.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Properties/AssemblyInfo.cs
@@ -10,6 +10,6 @@ using System.Runtime.CompilerServices;
                                                        "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
                                                        "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
                                                        "b19485ec")]
-[assembly: AssemblyVersion("8.50.3.0")]
-[assembly: AssemblyInformationalVersion("8.50.3.0")]
-[assembly: AssemblyFileVersion("8.50.3.0")]
+[assembly: AssemblyVersion("8.51.1.0")]
+[assembly: AssemblyInformationalVersion("8.51.1.0")]
+[assembly: AssemblyFileVersion("8.51.1.0")]

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>8.50.3</VersionPrefix>
+    <VersionPrefix>8.51.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Michiel van Oudheusden, Martijn Laarman, Mogens Heller Grabe, Serilog Contributors</Authors>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/RollingIntervalExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/RollingIntervalExtensions.cs
@@ -45,13 +45,17 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                     return "\\d{8}";
                 case RollingInterval.Hour:
                     //return "\\d{10}";
-                    // VT-5543: Added here to support old hour format - "yyyyMMdd-HH". Can be removed after migration in favor of commented line
-                    return "((\\d{8}-\\d{2})|(\\d{10}))";
+                    // VT-5543: Added old format to support old hour format - "yyyyMMdd-HH". Can be removed after migration in favor of commented line
+                    return "(("+OldHourlyDateRegExp+")|(\\d{10}))";
                 case RollingInterval.Minute:
                     return "\\d{12}";
                 default:
                     throw new ArgumentException("Invalid rolling interval");
             }
         }
+
+        // VT-5543: These could be removed after migration
+        internal const string OldHourlyDateFormat = "yyyyMMdd-HH";
+        internal const string OldHourlyDateRegExp = "\\d{8}-\\d{2}";
     }
 }

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/RollingIntervalExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/RollingIntervalExtensions.cs
@@ -44,7 +44,9 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                 case RollingInterval.Day:
                     return "\\d{8}";
                 case RollingInterval.Hour:
-                    return "\\d{10}";
+                    //return "\\d{10}";
+                    // VT-5543: Added here to support old hour format - "yyyyMMdd-HH". Can be removed after migration in favor of commented line
+                    return "((\\d{8}-\\d{2})|(\\d{10}))";
                 case RollingInterval.Minute:
                     return "\\d{12}";
                 default:

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchPayloadReaderTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchPayloadReaderTests.cs
@@ -118,14 +118,18 @@ public class ElasticsearchPayloadReaderTests : IDisposable
             .WithMessage("Rolling intervals less frequent than RollingInterval.Day are not supported");
     }
     
-    [Fact]
+    [Theory]
+    [InlineData(RollingIntervalExtensions.OldHourlyDateFormat)]
+    [InlineData("yyyyMMdd-HH_001")]
+    [InlineData("yyyyMMdd-HH_010")]
+    [InlineData("yyyyMMdd-HH_100")]
+    [InlineData("yyyyMMdd-HH_1000")]
     // VT-5543: Can be removed after migration to new format
     // Ensures that reader understands old hourly date format "yyyyMMdd-HH" for buffer files. This date format was for Hourly files before move to standard "yyyyMMddHH"
-    public void ReadPayload_ShouldReadOldHourlyDateFormat()
+    public void ReadPayload_ShouldReadOldHourlyDateFormat(string format)
     {
         // Arrange
         var rollingInterval = RollingInterval.Hour;
-        var format = RollingIntervalExtensions.OldHourlyDateFormat;
         var payloadReader = new ElasticsearchPayloadReader("testPipelineName",
             "TestTypeName",
             null,

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchPayloadReaderTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchPayloadReaderTests.cs
@@ -125,7 +125,7 @@ public class ElasticsearchPayloadReaderTests : IDisposable
     {
         // Arrange
         var rollingInterval = RollingInterval.Hour;
-        var format = "yyyyMMdd-HH";
+        var format = RollingIntervalExtensions.OldHourlyDateFormat;
         var payloadReader = new ElasticsearchPayloadReader("testPipelineName",
             "TestTypeName",
             null,

--- a/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
@@ -72,14 +72,14 @@ public class FileSetTests : IDisposable
     public void GetBufferFiles_BothNewAndOldHourlyFormatsAreSupported_andOldSortedFirst()
     {
         // Arrange
-        var rollingInterval = RollingInterval.Hour;
-        var oldFormat = "yyyyMMdd-HH";
+        const RollingInterval rollingInterval = RollingInterval.Hour;
+        const string oldFormat = "yyyyMMdd-HH";
         var newFormat = rollingInterval.GetFormat();
         _bufferFileNames = new Dictionary<RollingInterval, string>
         {
             {RollingInterval.Hour, GenerateBufferFile(oldFormat, oldFormat)},
             // adding with arbitrary interval to Dictionary for a proper clean up (already have Hour filled)
-            {RollingInterval.Day, GenerateBufferFile(oldFormat, newFormat)}
+            {RollingInterval.Day, GenerateBufferFile(newFormat, newFormat)}
         };
         var fileSet = new FileSet(_fileNameBase, rollingInterval);
         var hourlyBufferFileForOldFormat = _bufferFileNames[RollingInterval.Hour];
@@ -89,8 +89,7 @@ public class FileSetTests : IDisposable
         var bufferFiles = fileSet.GetBufferFiles();
 
         // Assert
-        bufferFiles.ShouldBeEquivalentTo(new[] {hourlyBufferFileForOldFormat, hourlyBufferFileForNewFormat},
-            options => options.WithStrictOrdering());
+        bufferFiles.Should().Equal(hourlyBufferFileForOldFormat, hourlyBufferFileForNewFormat);
     }
 
     /// <summary>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
@@ -55,7 +55,7 @@ public class FileSetTests : IDisposable
     {
         // Arrange
         var rollingInterval = RollingInterval.Hour;
-        var format = "yyyyMMdd-HH";
+        var format = RollingIntervalExtensions.OldHourlyDateFormat;
         _bufferFileNames = GenerateFilesUsingFormat(format);
         var fileSet = new FileSet(_fileNameBase, rollingInterval);
         var bufferFileForInterval = _bufferFileNames[rollingInterval];

--- a/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
@@ -48,14 +48,18 @@ public class FileSetTests : IDisposable
         bufferFiles.Should().BeEquivalentTo(bufferFileForInterval);
     }
 
-    [Fact]
+    [Theory]
+    [InlineData(RollingIntervalExtensions.OldHourlyDateFormat)]
+    [InlineData("yyyyMMdd-HH_001")]
+    [InlineData("yyyyMMdd-HH_010")]
+    [InlineData("yyyyMMdd-HH_100")]
+    [InlineData("yyyyMMdd-HH_1000")]
     // VT-5543: Can be removed after migration to new format
     // Ensures that date format "yyyyMMdd-HH" is supported by Hourly interval. This date format was for Hourly files before move to standard "yyyyMMddHH"
-    public void GetBufferFiles_SupportOldHourlyFormat()
+    public void GetBufferFiles_SupportOldHourlyFormat(string format)
     {
         // Arrange
         var rollingInterval = RollingInterval.Hour;
-        var format = RollingIntervalExtensions.OldHourlyDateFormat;
         _bufferFileNames = GenerateFilesUsingFormat(format);
         var fileSet = new FileSet(_fileNameBase, rollingInterval);
         var bufferFileForInterval = _bufferFileNames[rollingInterval];
@@ -75,11 +79,10 @@ public class FileSetTests : IDisposable
     {
         // Arrange
         const RollingInterval rollingInterval = RollingInterval.Hour;
-        const string oldFormat = "yyyyMMdd-HH";
         var newFormat = rollingInterval.GetFormat();
         _bufferFileNames = new Dictionary<RollingInterval, string>
         {
-            {RollingInterval.Hour, GenerateBufferFile(oldFormat, oldFormat)},
+            {RollingInterval.Hour, GenerateBufferFile(RollingIntervalExtensions.OldHourlyDateFormat, RollingIntervalExtensions.OldHourlyDateFormat)},
             // adding with arbitrary interval to Dictionary for a proper clean up (already have Hour filled)
             {RollingInterval.Day, GenerateBufferFile(newFormat, newFormat)}
         };

--- a/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
@@ -49,6 +49,7 @@ public class FileSetTests : IDisposable
     }
 
     [Fact]
+    // VT-5543: Can be removed after migration to new format
     // Ensures that date format "yyyyMMdd-HH" is supported by Hourly interval. This date format was for Hourly files before move to standard "yyyyMMddHH"
     public void GetBufferFiles_SupportOldHourlyFormat()
     {
@@ -68,6 +69,7 @@ public class FileSetTests : IDisposable
 
 
     [Fact]
+    // VT-5543: Can be removed after migration to new format
     // Ensures that both date formats are supported simultaneously: "yyyyMMdd-HH"(old) and "yyyyMMddHH" (new)
     public void GetBufferFiles_BothNewAndOldHourlyFormatsAreSupported_andOldSortedFirst()
     {

--- a/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
@@ -22,10 +22,7 @@ public class FileSetTests : IDisposable
 
     public void Dispose()
     {
-        foreach (var bufferFileName in _bufferFileNames.Values)
-        {
-            System.IO.File.Delete(bufferFileName);
-        }
+        foreach (var bufferFileName in _bufferFileNames.Values) System.IO.File.Delete(bufferFileName);
     }
 
     [Theory]
@@ -51,8 +48,53 @@ public class FileSetTests : IDisposable
         bufferFiles.Should().BeEquivalentTo(bufferFileForInterval);
     }
 
+    [Fact]
+    // Ensures that date format "yyyyMMdd-HH" is supported by Hourly interval. This date format was for Hourly files before move to standard "yyyyMMddHH"
+    public void GetBufferFiles_SupportOldHourlyFormat()
+    {
+        // Arrange
+        var rollingInterval = RollingInterval.Hour;
+        var format = "yyyyMMdd-HH";
+        _bufferFileNames = GenerateFilesUsingFormat(format);
+        var fileSet = new FileSet(_fileNameBase, rollingInterval);
+        var bufferFileForInterval = _bufferFileNames[rollingInterval];
+
+        // Act
+        var bufferFiles = fileSet.GetBufferFiles();
+
+        // Assert
+        bufferFiles.Should().BeEquivalentTo(bufferFileForInterval);
+    }
+
+
+    [Fact]
+    // Ensures that both date formats are supported simultaneously: "yyyyMMdd-HH"(old) and "yyyyMMddHH" (new)
+    public void GetBufferFiles_BothNewAndOldHourlyFormatsAreSupported_andOldSortedFirst()
+    {
+        // Arrange
+        var rollingInterval = RollingInterval.Hour;
+        var oldFormat = "yyyyMMdd-HH";
+        var newFormat = rollingInterval.GetFormat();
+        _bufferFileNames = new Dictionary<RollingInterval, string>
+        {
+            {RollingInterval.Hour, GenerateBufferFile(oldFormat, oldFormat)},
+            // adding with arbitrary interval to Dictionary for a proper clean up (already have Hour filled)
+            {RollingInterval.Day, GenerateBufferFile(oldFormat, newFormat)}
+        };
+        var fileSet = new FileSet(_fileNameBase, rollingInterval);
+        var hourlyBufferFileForOldFormat = _bufferFileNames[RollingInterval.Hour];
+        var hourlyBufferFileForNewFormat = _bufferFileNames[RollingInterval.Day];
+
+        // Act
+        var bufferFiles = fileSet.GetBufferFiles();
+
+        // Assert
+        bufferFiles.ShouldBeEquivalentTo(new[] {hourlyBufferFileForOldFormat, hourlyBufferFileForNewFormat},
+            options => options.WithStrictOrdering());
+    }
+
     /// <summary>
-    /// Generates buffer files for all RollingIntervals and returns dictionary of {rollingInterval, fileName} pairs.
+    ///     Generates buffer files for all RollingIntervals and returns dictionary of {rollingInterval, fileName} pairs.
     /// </summary>
     /// <param name="format"></param>
     /// <returns></returns>
@@ -61,14 +103,20 @@ public class FileSetTests : IDisposable
         var result = new Dictionary<RollingInterval, string>();
         foreach (var rollingInterval in Enum.GetValues(typeof(RollingInterval)))
         {
-            var bufferFileName = string.Format(_tempFileFullPathTemplate,
-                string.IsNullOrEmpty(format) ? string.Empty : new DateTime(2000, 1, 1).ToString(format));
-            var lines = new[] {rollingInterval.ToString()};
-            // Important to use UTF8 with BOM if we are starting from 0 position 
-            System.IO.File.WriteAllLines(bufferFileName, lines, new UTF8Encoding(true));
+            var bufferFileName = GenerateBufferFile(format, rollingInterval.ToString());
             result.Add((RollingInterval) rollingInterval, bufferFileName);
         }
 
         return result;
+    }
+
+    private string GenerateBufferFile(string format, string content)
+    {
+        var bufferFileName = string.Format(_tempFileFullPathTemplate,
+            string.IsNullOrEmpty(format) ? string.Empty : new DateTime(2000, 1, 1).ToString(format));
+        var lines = new[] {content};
+        // Important to use UTF8 with BOM if we are starting from 0 position 
+        System.IO.File.WriteAllLines(bufferFileName, lines, new UTF8Encoding(true));
+        return bufferFileName;
     }
 }


### PR DESCRIPTION
[VT-5543]
!!! No need to merge, just need to release version after review.
- Add support for these to `FileSet` properly find both type of files.
- Add support to `ElasticsearchPayloadReader` to be able to read payload from such files, It is parsing date from the file name.
- Added tests
- This code is SV specific. Could be removed after launch, as later there should be no old format hourly buffer files. So no need to create a PR to merge to serilog.

[VT-5543]: https://agileharbor.atlassian.net/browse/VT-5543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ